### PR TITLE
cargo: fix deku commit specification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 [[package]]
 name = "deku"
 version = "0.19.1"
-source = "git+https://github.com/sharksforarms/deku.git#e5363bc11e123bfcfd3467a2a90aeef8b588f432"
+source = "git+https://github.com/sharksforarms/deku.git?rev=e5363bc11e123bfcfd3467a2a90aeef8b588f432#e5363bc11e123bfcfd3467a2a90aeef8b588f432"
 dependencies = [
  "deku_derive",
  "no_std_io2",
@@ -272,7 +272,7 @@ dependencies = [
 [[package]]
 name = "deku_derive"
 version = "0.19.1"
-source = "git+https://github.com/sharksforarms/deku.git#e5363bc11e123bfcfd3467a2a90aeef8b588f432"
+source = "git+https://github.com/sharksforarms/deku.git?rev=e5363bc11e123bfcfd3467a2a90aeef8b588f432#e5363bc11e123bfcfd3467a2a90aeef8b588f432"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0-only"
 
 [dependencies]
 crc = "3.2.1"
-deku = { git = "https://github.com/sharksforarms/deku.git", commit = "e5363bc11e123bfcfd3467a2a90aeef8b588f432", default-features = false }
+deku = { git = "https://github.com/sharksforarms/deku.git", rev = "e5363bc11e123bfcfd3467a2a90aeef8b588f432", default-features = false }
 flagset = { version = "0.4.7", default-features = false }
 heapless = "0.8.0"
 hmac = { version = "0.12.1", default-features = false }


### PR DESCRIPTION
I get:

    $ cargo build
    warning: unused manifest key: dependencies.deku.commit

This should be `rev` instead.