### PR TITLE
README: Update use statement to reflect current module hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ creates two namespaces in a subsystem with one controller, one PCIe port, and
 one two-wire port. One of the namespaces is attached to the controller:
 
 ```rust
-use nvme_mi_dev::nvme::{
-    ManagementEndpoint, PciePort, PortType, Subsystem, SubsystemInfo, TwoWirePort,
+use nvme_mi_dev::{
+    ManagementEndpoint, PciePort, PortType, Subsystem, SubsystemInfo,
+    TwoWirePort,
 };
 
 async fn nvme_mi<'a>(router: &'a Router<'a>) -> std::io::Result<()> {


### PR DESCRIPTION
5cfa83666008 ("tree-wide: Improve organisation of the tree") rearranged where types were exposed by the library, so update the README to reflect that.

Fixes: 5cfa83666008 ("tree-wide: Improve organisation of the tree")