### PR TITLE
cargo: Bump deku tag to cc/deku-v0.19.1/bit-precise-no-alloc-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 [[package]]
 name = "deku"
 version = "0.20.0"
-source = "git+https://github.com/codeconstruct/deku.git?tag=cc%2Fdeku-v0.19.1%2Fbit-precise-no-alloc-1#036c221dc47aca4890db20e08d381bb32bc788f6"
+source = "git+https://github.com/codeconstruct/deku.git?tag=cc%2Fdeku-v0.19.1%2Fbit-precise-no-alloc-2#54ab0160bd1e9cfdcc3a7f81993a6168d02893e8"
 dependencies = [
  "bitvec",
  "deku_derive",
@@ -285,7 +285,7 @@ dependencies = [
 [[package]]
 name = "deku_derive"
 version = "0.20.0"
-source = "git+https://github.com/codeconstruct/deku.git?tag=cc%2Fdeku-v0.19.1%2Fbit-precise-no-alloc-1#036c221dc47aca4890db20e08d381bb32bc788f6"
+source = "git+https://github.com/codeconstruct/deku.git?tag=cc%2Fdeku-v0.19.1%2Fbit-precise-no-alloc-2#54ab0160bd1e9cfdcc3a7f81993a6168d02893e8"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0-only"
 
 [dependencies]
 crc = "3.2.1"
-deku = { git = "https://github.com/codeconstruct/deku.git", tag = "cc/deku-v0.19.1/bit-precise-no-alloc-1", default-features = false, features = ["bits"] }
+deku = { git = "https://github.com/codeconstruct/deku.git", tag = "cc/deku-v0.19.1/bit-precise-no-alloc-2", default-features = false, features = ["bits"] }
 flagset = { version = "0.4.7", default-features = false }
 heapless = "0.8.0"
 hmac = { version = "0.12.1", default-features = false }


### PR DESCRIPTION
Fix the build for usbnvme. Previously the read padding still required linking against alloc.