### PR TITLE
cargo: Update deku to the v0.20.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,8 +273,9 @@ dependencies = [
 
 [[package]]
 name = "deku"
-version = "0.20.0"
-source = "git+https://github.com/sharksforarms/deku.git?rev=4fb3527a86222f3680c27df473bde534974a5cdc#4fb3527a86222f3680c27df473bde534974a5cdc"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4b7f93fb332e3f95282eaf53ec39b10b73a01c6aebc97033593c37d3839caa"
 dependencies = [
  "bitvec",
  "deku_derive",
@@ -284,8 +285,9 @@ dependencies = [
 
 [[package]]
 name = "deku_derive"
-version = "0.20.0"
-source = "git+https://github.com/sharksforarms/deku.git?rev=4fb3527a86222f3680c27df473bde534974a5cdc#4fb3527a86222f3680c27df473bde534974a5cdc"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db279c48bd64249263ffbef3ec87c79ab38c6e6cd2be176107970ce90839d64d"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0-only"
 
 [dependencies]
 crc = "3.2.1"
-deku = { git = "https://github.com/sharksforarms/deku.git", rev = "4fb3527a86222f3680c27df473bde534974a5cdc", default-features = false, features = ["bits"] }
+deku = { version = "0.20.1", default-features = false, features = ["bits"] }
 flagset = { version = "0.4.7", default-features = false }
 heapless = "0.8.0"
 hmac = { version = "0.12.1", default-features = false }


### PR DESCRIPTION
It contains all the features needed for nvme-mi-dev.